### PR TITLE
Method chaining support

### DIFF
--- a/rainbowvis.js
+++ b/rainbowvis.js
@@ -30,18 +30,22 @@ function Rainbow()
 			}
 
 			colours = spectrum;
+			return this;
 		}
 	}
+
 	this.setColors = this.setColours;
 
 	this.setSpectrum = function () 
 	{
 		setColours(arguments);
+		return this;
 	}
 
 	this.setSpectrumByArray = function (array)
 	{
 		setColours(array);
+        return this;
 	}
 
 	this.colourAt = function (number)
@@ -56,6 +60,7 @@ function Rainbow()
 			return gradients[index].colourAt(number);
 		}
 	}
+
 	this.colorAt = this.colourAt;
 
 	this.setNumberRange = function (minNumber, maxNumber)
@@ -67,6 +72,7 @@ function Rainbow()
 		} else {
 			throw new RangeError('maxNumber (' + maxNumber + ') is not greater than minNumber (' + minNumber + ')');
 		}
+		return this;
 	}
 }
 


### PR DESCRIPTION
Method chaining can reduce lines of code and can be especially useful when new Rainbows are defined as object properties.

Was:

```
var rainbow1 = new Rainbow();
rainbow1.setNumberRange(0, 1);
rainbow1.setSpectrum('c0e0e8', '428696');

var rainbow2 = new Rainbow();
rainbow1.setNumberRange(0, 1);
rainbow1.setSpectrum('c0e8c2', '429756');

var myColourScheme = {
    'blues': rainbow1,
    'greens': rainbow2
};
```

Now:

```
var myColourScheme = {
    'blues': new Rainbow().setNumberRange(0, 1).setSpectrum('c0e0e8', '428696'),
    'greens': new Rainbow().setNumberRange(0, 1).setSpectrum('c0e8c2', '429756')
};
```
