### PR TITLE
exports as commonjs module

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,0 +1,25 @@
+{
+  "name": "rainbowvis.js",
+  "version": "0.0.0",
+  "description": "A JavaScript library for colour data visualization. Easily map numbers to a smooth-transitioning colour legend. ",
+  "main": "rainbowvis.js",
+  "scripts": {
+    "test": "echo \"Error: no test specified\" && exit 1"
+  },
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/anomal/RainbowVis-JS.git"
+  },
+  "keywords": [
+    "color",
+    "rainbow",
+    "visualization",
+    "pallete"
+  ],
+  "author": "Sophiah (Zing-Ming) <zingming+github@gmail.com>",
+  "license": "EPL",
+  "bugs": {
+    "url": "https://github.com/anomal/RainbowVis-JS/issues"
+  },
+  "homepage": "https://github.com/anomal/RainbowVis-JS"
+}

--- a/rainbowvis.js
+++ b/rainbowvis.js
@@ -303,3 +303,6 @@ function ColourGradient()
 	}
 }
 
+if (typeof module !== 'undefined') {
+  module.exports = Rainbow;
+}


### PR DESCRIPTION
Now rainbowvis.js exports as commonjs module. And added package.json.

Now you can publish on npm using: 
```
npm publish
```
Please update README.md file also to show usage:

## installation
```
npm install rainbowvis.js
```
## usage
```javascript
var Rainbow = require('rainbowvis.js');
var myRainbow = new Rainbow();
``` 
